### PR TITLE
fix so openmpi with verbs works outside build server

### DIFF
--- a/rpmbuild/SPECS/openmpi-2.1.1-gcb01.spec
+++ b/rpmbuild/SPECS/openmpi-2.1.1-gcb01.spec
@@ -156,7 +156,6 @@ cd "$FASRCSW_DEV"/rpmbuild/BUILD/%{name}-%{version}
 	--infodir=%{_prefix}/share/info \
 	--enable-mpi-thread-multiple \
     --enable-static \
-    --enable-mpi-fortran=all \
 	--enable-mpi-cxx \
 	--with-hwloc \
     --enable-mpi-java \


### PR DESCRIPTION
Outside of the build server the module would not load.
Spider could find it but it would not load.
I think this may be due to the previous openmpi modules
being built as Core and I was trying to build this as Comp.
I am now building this as Core and this requires removing
fortran openmpi support.