### PR TITLE
Fix Anaconda3 activate command

### DIFF
--- a/rpmbuild/SPECS/Anaconda3-2019.10-gcb02.spec
+++ b/rpmbuild/SPECS/Anaconda3-2019.10-gcb02.spec
@@ -1,0 +1,345 @@
+#------------------- package info ----------------------------------------------
+
+# binary package
+%define __prelink_undo_cmd %{nil}
+
+#
+# enter the simple app name, e.g. myapp
+#
+Name: %{getenv:NAME}
+
+#
+# enter the app version, e.g. 0.0.1
+#
+Version: %{getenv:VERSION}
+
+#
+# enter the release; start with fasrc01 (or some other convention for your 
+# organization) and increment in subsequent releases
+#
+# the actual "Release", %%{release_full}, is constructed dynamically; for Comp 
+# and MPI apps, it will include the name/version/release of the apps used to 
+# build it and will therefore be very long
+#
+%define release_short %{getenv:RELEASE}
+
+#
+# enter your FIRST LAST <EMAIL>
+#
+Packager: %{getenv:FASRCSW_AUTHOR}
+
+#
+# enter a succinct one-line summary (%%{summary} gets changed when the debuginfo 
+# rpm gets created, so this stores it separately for later re-use); do not 
+# surround this string with quotes
+#
+%define summary_static a Python distribution for large-scale data processing, predictive analytics, and scientific computing
+Summary: %{summary_static}
+
+#
+# enter the url from where you got the source; change the archive suffix if 
+# applicable
+#
+URL: https://repo.anaconda.com/archive/Anaconda3-2019.10-Linux-x86_64.sh
+#Source: %{name}-%{version}.tar.gz
+
+#
+# there should be no need to change the following
+#
+
+#these fields are required by RPM
+Group: fasrcsw
+License: see COPYING file or upstream packaging
+
+#this comes here since it uses Name and Version but dynamically computes Release, Prefix, etc.
+%include fasrcsw_defines.rpmmacros
+
+Release: %{release_full}
+Prefix: %{_prefix}
+
+#
+# Macros for setting app data 
+# The first set can probably be left as is
+# the nil construct should be used for empty values
+#
+%define modulename %{name}-%{version}-%{release_short}
+%define appname %(test %{getenv:APPNAME} && echo "%{getenv:APPNAME}" || echo "%{name}")
+%define appversion %(test %{getenv:APPVERSION} && echo "%{getenv:APPVERSION}" || echo "%{version}")
+%define appdescription %{summary_static}
+%define type %{getenv:TYPE}
+%define specauthor %{getenv:FASRCSW_AUTHOR}
+%define builddate %(date)
+%define buildhost %(hostname)
+%define buildhostversion 1
+%define compiler %( if [[ %{getenv:TYPE} == "Comp" || %{getenv:TYPE} == "MPI" ]]; then if [[ -n "%{getenv:FASRCSW_COMPS}" ]]; then echo "%{getenv:FASRCSW_COMPS}"; fi; else echo "system"; fi)
+%define mpi %(if [[ %{getenv:TYPE} == "MPI" ]]; then if [[ -n "%{getenv:FASRCSW_MPIS}" ]]; then echo "%{getenv:FASRCSW_MPIS}"; fi; else echo ""; fi)
+
+
+%define builddependencies gcc/6.2.0-fasrc01 
+%define rundependencies %{builddependencies}
+#%define buildcomments Remove hdf5 h5py AND libgcc.  This removes matplotlib and a number of others
+%define requestor %{nil}
+%define requestref %{nil}
+
+# apptags
+# For aci-ref database use aci-ref-app-category and aci-ref-app-tag namespaces and separate tags with a semi-colon
+# aci-ref-app-category:Programming Tools; aci-ref-app-tag:Compiler
+%define apptags %{nil} 
+%define apppublication %{nil}
+
+
+
+#
+# enter a description, often a paragraph; unless you prefix lines with spaces, 
+# rpm will format it, so no need to worry about the wrapping
+#
+%description
+A completely free enterprise-ready Python distribution for large-scale data processing, predictive analytics, and scientific computing, from Continuum Analytics.
+
+
+
+#------------------- %%prep (~ tar xvf) ---------------------------------------
+
+%prep
+
+#
+# unpack the sources here.  The default below is for standard, GNU-toolchain 
+# style things
+#
+
+#(do nothing)
+
+
+
+#------------------- %%build (~ configure && make) ----------------------------
+
+%build
+
+#
+# configure and make the software here; the default below is for standard 
+# GNU-toolchain style things
+# 
+
+#(leave this here)
+%include fasrcsw_module_loads.rpmmacros
+
+##prerequisite apps (uncomment and tweak if necessary)
+#module load NAME/VERSION-RELEASE
+
+#(do nothing)
+
+
+
+#------------------- %%install (~ make install + create modulefile) -----------
+
+%install
+
+#
+# make install here; the default below is for standard GNU-toolchain style 
+# things; plus we add some handy files (if applicable) and build a modulefile
+#
+
+#(leave this here)
+%include fasrcsw_module_loads.rpmmacros
+
+#--- This app insists on writing directly to the prefix.  Complicating, things, 
+#    it also insists that the prefix not exist, so even the symlink hack needs 
+#    to be further hacked (introduce an additional sub-directory).
+
+# Standard stuff.
+echo %{buildroot} | grep -q %{name}-%{version} && rm -rf %{buildroot}
+mkdir -p %{buildroot}/%{_prefix}
+
+# Symlink the final prefix (which the build insists on using), to the 
+# buildroot (the temporary place where we want to install it now).  
+# Note that this will fail if this is not the first build of this 
+# NAME/VERSION/RELEASE/TYPE.
+sudo mkdir -p "$(dirname %{_prefix})"
+sudo ln -s "%{buildroot}/%{_prefix}" "%{_prefix}"
+
+#base sharball execution
+#-b ~ batch, -p ~ prefix
+unset PYTHONPATH
+bash %{_topdir}/SOURCES/%{name}-%{version}-Linux-x86_64.sh -b -p "%{_prefix}"/x
+
+# Remove hdf5 so that a local version can be created when needed.
+# Remove Qt* and gstreamer* to permit rpm build (reduce # packaged files)
+for pkg in hdf5 Qt* ; do
+   %{_prefix}/x/bin/conda remove --yes $pkg
+done
+
+
+# Clean up that symlink.  The parent dir may be left over, oh well.
+sudo rm "%{_prefix}"
+
+#---
+
+
+#this is the part that allows for inspecting the build output without fully creating the rpm
+#there should be no need to change this
+%if %{defined trial}
+	set +x
+	
+	echo
+	echo
+	echo "*************** fasrcsw -- STOPPING due to %%define trial yes ******************"
+	echo 
+	echo "Look at the tree output below to decide how to finish off the spec file.  (\`Bad"
+	echo "exit status' is expected in this case, it's just a way to stop NOW.)"
+	echo
+	echo
+	
+	tree '%{buildroot}/%{_prefix}'
+
+	echo
+	echo
+	echo "Some suggestions of what to use in the modulefile:"
+	echo
+	echo
+
+	generate_setup.sh --action echo --format lmod --prefix '%%{_prefix}'  '%{buildroot}/%{_prefix}'
+
+	echo
+	echo
+	echo "******************************************************************************"
+	echo
+	echo
+	
+	#make the build stop
+	false
+
+	set -x
+%endif
+
+# 
+# - uncomment any applicable prepend_path things
+#
+# - do any other customizing of the module, e.g. load dependencies
+#
+# - in the help message, link to website docs rather than write anything 
+#   lengthy here
+#
+# references on writing modules:
+#   http://www.tacc.utexas.edu/tacc-projects/lmod/advanced-user-guide/writing-module-files
+#   http://www.tacc.utexas.edu/tacc-projects/lmod/system-administrator-guide/initial-setup-of-modules
+#   http://www.tacc.utexas.edu/tacc-projects/lmod/system-administrator-guide/module-commands-tutorial
+#
+
+# FIXME (but the above is enough for a "trial" build)
+
+cat > %{buildroot}/%{_prefix}/modulefile.lua <<EOF
+local helpstr = [[
+%{name}-%{version}-%{release_short}
+%{summary_static}
+]]
+help(helpstr,"\n")
+
+whatis("Name: %{name}")
+whatis("Version: %{version}-%{release_short}")
+whatis("Description: %{summary_static}")
+
+-- environment changes (uncomment what is relevant)
+setenv("PYTHON_HOME",               "%{_prefix}/x")
+setenv("PYTHON_INCLUDE",            "%{_prefix}/x/include")
+setenv("PYTHON_LIB",                "%{_prefix}/x/lib")
+prepend_path("PATH",                "%{_prefix}/x/bin")
+
+execute{cmd="source " .. "/nfs/software/helmod/apps/Core/Anaconda3/2019.10-gcb02/x/etc/profile.d/conda.sh",modeA={"load"}}
+
+if (mode() == "unload") then
+    prepend_path("PATH", "/nfs/software/helmod/apps/Core/Anaconda3/2019.10-gcb02/x/condabin")
+end
+cmd = "unset CONDA_EXE; unset _CE_CONDA; unset _CE_M; " ..
+        "unset -f __conda_activate; unset -f __conda_reactivate; " ..
+        "unset -f __conda_hashr; unset CONDA_SHLVL; unset _CONDA_EXE; " ..
+        "unset _CONDA_ROOT; unset -f conda"
+execute{cmd=cmd, modeA={"unload"}}
+
+EOF
+
+#------------------- App data file
+cat > $FASRCSW_DEV/appdata/%{modulename}.%{type}.dat <<EOF
+appname             : %{appname}
+appversion          : %{appversion}
+description         : %{appdescription}
+tags                : %{apptags}
+publication         : %{apppublication}
+modulename          : %{modulename}
+type                : %{type}
+compiler            : %{compiler}
+mpi                 : %{mpi}
+specauthor          : %{specauthor}
+builddate           : %{builddate}
+buildhost           : %{buildhost}
+buildhostversion    : %{buildhostversion}
+builddependencies   : %{builddependencies}
+rundependencies     : %{rundependencies}
+buildcomments       : %{buildcomments}
+requestor           : %{requestor}
+requestref          : %{requestref}
+EOF
+
+
+
+#------------------- %%files (there should be no need to change this ) --------
+
+%files
+
+%defattr(-,root,root,-)
+
+%{_prefix}/*
+
+
+
+#------------------- scripts (there should be no need to change these) --------
+
+
+%pre
+#
+# everything in fasrcsw is installed in an app hierarchy in which some 
+# components may need creating, but no single rpm should own them, since parts 
+# are shared; only do this if it looks like an app-specific prefix is indeed 
+# being used (that is the fasrcsw default)
+#
+echo '%{_prefix}' | grep -q '%{name}.%{version}' && mkdir -p '%{_prefix}'
+#
+
+%post
+#
+# symlink to the modulefile installed along with the app; we want all rpms to 
+# be relocatable, hence why this is not a proper %%file; as with the app itself, 
+# modulefiles are in an app hierarchy in which some components may need 
+# creating
+#
+mkdir -p %{modulefile_dir}
+ln -s %{_prefix}/modulefile.lua %{modulefile}
+#
+
+
+%preun
+#
+# undo the module file symlink done in the %%post; do not rmdir 
+# %%{modulefile_dir}, though, since that is shared by multiple apps (yes, 
+# orphans will be left over after the last package in the app family 
+# is removed)
+#
+test -L '%{modulefile}' && rm '%{modulefile}'
+#
+
+%postun
+#
+# undo the last component of the mkdir done in the %%pre (yes, orphans will be 
+# left over after the last package in the app family is removed); also put a 
+# little protection so this does not cause problems if a non-default prefix 
+# (e.g. one shared with other packages) is used
+#
+test -d '%{_prefix}' && echo '%{_prefix}' | grep -q '%{name}.%{version}' && rmdir '%{_prefix}'
+#
+
+
+%clean
+#
+# wipe out the buildroot, but put some protection to make sure it isn't 
+# accidentally / or something -- we always have "rpmbuild" in the name
+#
+echo '%{buildroot}' | grep -q 'rpmbuild' && rm -rf '%{buildroot}'

--- a/rpmbuild/SPECS/Anaconda3-2019.10-gcb02.spec
+++ b/rpmbuild/SPECS/Anaconda3-2019.10-gcb02.spec
@@ -164,7 +164,7 @@ bash %{_topdir}/SOURCES/%{name}-%{version}-Linux-x86_64.sh -b -p "%{_prefix}"/x
 
 # Remove hdf5 so that a local version can be created when needed.
 # Remove Qt* and gstreamer* to permit rpm build (reduce # packaged files)
-for pkg in hdf5 Qt* ; do
+for pkg in hdf5 beautifulsoup4 Qt* ; do
    %{_prefix}/x/bin/conda remove --yes $pkg
 done
 


### PR DESCRIPTION
## Setup activate when module loads
Previously the "conda activate" command would fail and ask the user to run "conda init". This command would then add config to the users .bashrc and automatically add conda to the PATH. This pollutes all jobs run by that user on the cluster.
Changes here perform the minimal setup steps as part of "module load Anaconda3..." avoiding the need to pollute the users .bashrc file. Loosely based on fix here: https://github.com/CHPC-UofU/Lmod-setup/blob/master/2019.03.lua

Change different from Anaconda3-2019.10-gcb01.spec:
https://github.com/Duke-GCB/helmod/blob/a9fb87becd4d35c5fa97bb262053b4d0ac75e903/rpmbuild/SPECS/Anaconda3-2019.10-gcb02.spec#L247-L256

## Too many files error
I also hit the problem the too many files in an rpm: https://github.com/Duke-GCB/helmod/commit/a9fb87becd4d35c5fa97bb262053b4d0ac75e903
To fix this I added [beautifulsoup4](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) to the remove list. 
This will remove beautifulsoup4 from the base conda environment. 
This fix is similar to what we already do with qt modules.

Change different from Anaconda3-2019.10-gcb01.spec:
https://github.com/Duke-GCB/helmod/blob/a9fb87becd4d35c5fa97bb262053b4d0ac75e903/rpmbuild/SPECS/Anaconda3-2019.10-gcb02.spec#L167-L169